### PR TITLE
Fuss with configure.ac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# autoreconf -if
+/build-aux/
+/configure
+/aclocal.m4
+/autom4te.cache/
+Makefile.in
+
+# ./configure
+/config.log
+/config.status
+Makefile
+.deps/
+
+# make
+/src/awf-gtk?
+*.o

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,6 @@
 AC_INIT([A widget factory], [2.8.0])
 AC_CONFIG_SRCDIR([src/awf.c])
+AC_CONFIG_AUX_DIR([build-aux])
 
 AM_INIT_AUTOMAKE([foreign])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 AC_INIT([A widget factory], [2.8.0])
 AC_CONFIG_SRCDIR([src/awf.c])
 
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([foreign])
 
 AC_PROG_CC
 AM_PROG_CC_C_O


### PR DESCRIPTION
Hi! I'm sorry your packaging request for Parabola went ignored for a long time.

I was a little perplexed at the
```bash
  touch {NEWS,AUTHORS,README,ChangeLog}
  mv LICENSE COPYING
```
lines in your AUR `PKGBUILD`. And then I realized "ah, they're running automake in strict this-is-a-GNU-package mode", so here's a commit to add the `([foreign])` argument to make it suitably lax.

And then I also fussed with `.gitignore` so that I could more easily tell what the build is doing.

This PR does *not* adjust any of the packaging scripts.